### PR TITLE
add USE_ROUTING compiler arg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ if platform.system() == "Windows":
         "-DWIN32_LEAN_AND_MEAN",
         "-DASIO_STANDALONE",
         "-DUSE_PYTHON_BINDINGS",
+        "-DUSE_ROUTING=true"
     ]
     extra_link_args = []
 
@@ -36,6 +37,7 @@ else:  # anything *nix
         "-DASIO_STANDALONE",
         "-DNDEBUG",
         "-DUSE_PYTHON_BINDINGS",
+        "-DUSE_ROUTING=true"
     ]
     extra_link_args = [
         "-lpthread",


### PR DESCRIPTION
Should build the lib with `USE_ROUTING=true`. No test, little time at the moment. Eventually IMO we should add some (HTTP) integration test with at least one router.