### PR TITLE
Bugfix: Parses latitude and longitude as doubles instead of integers

### DIFF
--- a/src/bind/solution/solution.cpp
+++ b/src/bind/solution/solution.cpp
@@ -17,8 +17,8 @@ struct _Step {
   int64_t service;
   int64_t waiting_time;
   int64_t distance;
-  int64_t longitude;
-  int64_t latitude;
+  double longitude;
+  double latitude;
   int64_t location_index;
   int64_t id;
 

--- a/src/vroom/solution/solution.py
+++ b/src/vroom/solution/solution.py
@@ -70,8 +70,8 @@ class Solution(_vroom.Solution):
                 "service": array["service"],
                 "waiting_time": array["waiting_time"],
                 "location_index": array["location_index"],
-                "longitude": pandas.array(array["longitude"], dtype="Int64"),
-                "latitude": pandas.array(array["latitude"], dtype="Int64"),
+                "longitude": pandas.array(array["longitude"]),
+                "latitude": pandas.array(array["latitude"]),
                 "id": pandas.array(array["id"], dtype="Int64"),
                 "description": array["description"].astype("U40"),
             }


### PR DESCRIPTION
Decimals in coordinate values were being clipped away when cast into integers.