### PR TITLE
Fixes "non-None" timeout in solve func

### DIFF
--- a/src/vroom/input/input.py
+++ b/src/vroom/input/input.py
@@ -376,9 +376,7 @@ class Input(_vroom.Input):
             timeout:
                 Stop the solving process after a given amount of time.
         """
-        assert timeout is None or isinstance(timeout, (None, timedelta)), (
-            f"unknown timeout type: {timeout}"
-        )
+        assert timeout is None or isinstance(timeout, timedelta), f"unknown timeout type: {timeout}"
         solution = Solution(
             self._solve(
                 exploration_level=int(exploration_level),


### PR DESCRIPTION
# Description

Fixes a small bug when passing an actual `timedelta` to the `solve` func. The change simply removes the redundant check for `None` as a type, which Python does not consider a proper type (apparently that would be `type(None)` instead, but is not necessary anyway).

## Changes

- Fixes `timeout` parameter of `solve` func for "non-None" values.

## Notes

Thanks for all the work on the project. :heart: 

I hope this makes sense and is in an adequate form. I tried to keep it minimal.